### PR TITLE
Use cmake builtin `copy` instead of harcoded `cp`

### DIFF
--- a/extstore/posix_obj/CMakeLists.txt
+++ b/extstore/posix_obj/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library(extstore SHARED ${extstore_LIB_SRCS})
 target_link_libraries(extstore hiredis ini_config)
 
 add_custom_command(TARGET extstore
-                   COMMAND /usr/bin/cp libextstore.so ..)
+                   COMMAND ${CMAKE_COMMAND} -E copy libextstore.so ..)

--- a/extstore/posix_store/CMakeLists.txt
+++ b/extstore/posix_store/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library(extstore SHARED ${extstore_LIB_SRCS})
 target_link_libraries(extstore ini_config)
 
 add_custom_command(TARGET extstore
-                   COMMAND /usr/bin/cp libextstore.so ..)
+                   COMMAND ${CMAKE_COMMAND} -E copy libextstore.so ..)

--- a/extstore/rados/CMakeLists.txt
+++ b/extstore/rados/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library(extstore SHARED ${extstore_LIB_SRCS})
 target_link_libraries(extstore rados ini_config)
 
 add_custom_command(TARGET extstore
-                   COMMAND /usr/bin/cp libextstore.so ..)
+                   COMMAND ${CMAKE_COMMAND} -E copy libextstore.so ..)

--- a/kvsal/redis/CMakeLists.txt
+++ b/kvsal/redis/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library(kvsal SHARED ${kvsal_LIB_SRCS})
 target_link_libraries(kvsal hiredis ini_config)
 
 add_custom_command(TARGET kvsal
-                   COMMAND /usr/bin/cp libkvsal.so ..)
+                   COMMAND ${CMAKE_COMMAND} -E copy libkvsal.so ..)


### PR DESCRIPTION
By using cmake builtin copy command, we don't rely anymore on `cp`
executable being located at a specific place. For instance on
Debian systems, `cp` is located at `/bin/cp` but it may be found
at `/usr/bin/cp` on other systems.